### PR TITLE
switch to vendored hub release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,12 @@
 FROM ubuntu:18.04
 LABEL "maintainer"="LarsGohr@posteo.de"
 
+COPY hub-linux-amd64-2.12.3.tgz /hub-linux-amd64-2.12.3.tgz
+RUN tar -zxf /hub-linux-amd64-2.12.3.tgz -C / && rm /hub-linux-amd64-2.12.3.tgz
+
 RUN apt-get update \
   && apt-get install software-properties-common -y --no-install-recommends \
   && add-apt-repository ppa:cpick/hub \
   && apt-get update \
-  && apt-get install hub -y --no-install-recommends \
+  && /hub-linux-amd64-2.12.3/install \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This should fix the 401 issues with the `GITHUB_TOKEN`.

https://github.com/github/hub/issues/2249#issuecomment-527585430
https://github.com/LLNL/llnl.github.io/commit/2046d13c6321d40725fc8c1f5c33ee65ddcc9933